### PR TITLE
removed hardcoding for compression

### DIFF
--- a/src/mintpy/load_data.py
+++ b/src/mintpy/load_data.py
@@ -844,7 +844,7 @@ def load_data(inps):
             box=iDict['box4geo'],
             xstep=iDict['xstep'],
             ystep=iDict['ystep'],
-            compression='lzf')
+            compression=iDict['compression'])
 
     if run_or_skip(geom_radar_file, geom_radar_obj, iDict['box'], **kwargs) == 'run':
         geom_radar_obj.write2hdf5(
@@ -853,7 +853,7 @@ def load_data(inps):
             box=iDict['box'],
             xstep=iDict['xstep'],
             ystep=iDict['ystep'],
-            compression='lzf',
+            compression=iDict['compression'],
             extra_metadata=extraDict)
 
     # observations: ifgram, ion or offset


### PR DESCRIPTION
changed 'lzf' to iDict['compression']

**Description of proposed changes**

.h5 files were being compressed to 'lzf' despite a different input in the config file for compression. 

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
